### PR TITLE
Add permissions to pythonpublish.yml

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   deploy:
 


### PR DESCRIPTION
This PR adds the required permissions to the pythonpublish.yml workflow file.