### PR TITLE
Create release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Upload Python Package
 
 on:
-   release:
-     types: [created]
+  push:
+    branches:
+      - master
 
 jobs:
   release-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Upload Python Package
 
 on:
-  push:
-  # release:
-  #   types: [created]
+   release:
+     types: [created]
 
 jobs:
   release-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,19 +29,19 @@ jobs:
           name: release-dists
           path: dist/
 
-  # pypi-publish:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - release-build
-  #   permissions:
-  #     id-token: write
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write
+    environment: release
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
 
-  #   steps:
-  #     - name: Retrieve release distributions
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: release-dists
-  #         path: dist/
-
-  #     - name: Publish release distributions to PyPI
-  #       uses: pypa/gh-action-pypi-publish@3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   release-build:
     runs-on: ubuntu-latest
-
+    permissions:
+            contents: read
     steps:
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,4 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f
+        uses: pypa/gh-action-pypi-publish@e9ccbe5a211ba3e8363f472cae362b56b104e796

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Upload Python Package
+
+on:
+  push:
+  # release:
+  #   types: [created]
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f
+
+      - uses: actions/setup-python@532b046aaf352bab5717122cc0ea52b7f12266a3
+        with:
+          python-version: "3.x"
+
+      - name: build release distributions
+        run: |
+          # NOTE: put your own distribution build steps here.
+          python -m pip install build
+          python -m build
+
+      - name: upload to dists
+        uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8
+        with:
+          name: release-dists
+          path: dist/
+
+  # pypi-publish:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - release-build
+  #   permissions:
+  #     id-token: write
+
+  #   steps:
+  #     - name: Retrieve release distributions
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: release-dists
+  #         path: dist/
+
+  #     - name: Publish release distributions to PyPI
+  #       uses: pypa/gh-action-pypi-publish@3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     environment: release
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@448e3f862ab3ef47aa50ff917776823c9946035b
         with:
           name: release-dists
           path: dist/

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
      name='falconx',
-     version='1.0.5',
+     version='1.0.6',
      author="FalconX",
      author_email="support@falconx.io",
      description="The official client for FalconX APIs",


### PR DESCRIPTION
This pull request introduces the use of PYPI's trusted publisher and GitHub OIDC to automate the process of pushing to PyPI upon the creation of a new release, thereby eliminating the need for manual intervention.

Here is the published package link created from this workflow:
https://pypi.org/project/falconx/1.0.6/

This workflow will get triggered only when push is made to master, post which the workflow will build the package and push the same to pypi with the version defined in [setup.py](https://github.com/falconxio/falconx-python/blob/master/setup.py)