### PR TITLE
chore: migrate to ubuntu-2core for static IP allowlisting

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2core  # Static IP runner
 
     steps:
     - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2core  # Static IP runner
     permissions:
             contents: read
     steps:
@@ -30,7 +30,7 @@ jobs:
           path: dist/
 
   pypi-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2core  # Static IP runner
     needs:
       - release-build
     permissions:


### PR DESCRIPTION
This change migrates from ubuntu-latest to ubuntu-2core runner
to enable static IP addresses for IP allowlist compliance.

- Same specs as ubuntu-latest (2 cores, 8GB RAM)
- 25% cheaper ($0.006/min vs $0.008/min)
- Static IP for allowlist compliance

Committed via https://github.com/asottile/all-repos